### PR TITLE
New conan-cmake method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-
-MacWindow
-src/Imports/glfw
-src/Imports/glew
-build*
+bin/
+lib/
+lib64
+pyvenv.cfg
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,62 @@ project(FlatFoxEngine
     DESCRIPTION "A simple fox's game engine in C++"
 )
 
+file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
+include(${CMAKE_BINARY_DIR}/conan.cmake)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+
+conan_cmake_configure(
+    REQUIRES glew/2.2.0 glfw/3.3.8 glm/cci.20220420
+    GENERATORS cmake_find_package
+)
+
+conan_cmake_autodetect(settings)
+
+conan_cmake_install(
+    PATH_OR_REFERENCE .
+    BUILD missing
+    SETTINGS ${settings}
+)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_compile_options(-Wall -pedantic)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
 set(SOURCES
-    main.cpp src/FlatFoxRenderWarnings.cpp src/Renderer.cpp src/FlatFoxWindow.cpp src/FrameBufferObject.cpp src/SimplePhysics.cpp src/Camera.cpp src/SimpleObject.cpp src/VertexBuffer.cpp src/VertexArray.cpp src/IndexBuffer.cpp src/Shader.cpp src/Texture.cpp src/Imports/stb_image/stb_image.cpp  src/Seens/BasicMovement.cpp
+    main.cpp
+    src/FlatFoxRenderWarnings.cpp
+    src/Renderer.cpp
+    src/FlatFoxWindow.cpp
+    src/FrameBufferObject.cpp
+    src/SimplePhysics.cpp
+    src/Camera.cpp
+    src/SimpleObject.cpp
+    src/VertexBuffer.cpp
+    src/VertexArray.cpp
+    src/IndexBuffer.cpp
+    src/Shader.cpp
+    src/Texture.cpp
+    src/Imports/stb_image/stb_image.cpp
+    src/Seens/BasicMovement.cpp
 )
+
+find_package(GLEW REQUIRED)
+find_package(glfw3 REQUIRED)
+find_package(glm REQUIRED)
 
 add_executable(LinuxWindow ${SOURCES})
 
-target_include_directories(LinuxWindow PRIVATE src/Imports/stb_image)
+target_include_directories(LinuxWindow PRIVATE
+    src/Imports/stb_image
+)
 
-target_link_libraries(LinuxWindow PRIVATE ${CONAN_LIBS})
+target_link_libraries(LinuxWindow PRIVATE
+    GLEW::GLEW
+    glfw::glfw
+    glm::glm
+)
 
 install(TARGETS LinuxWindow DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@ To compile with Conan and CMake:
 
 ```bash
 # Install conan
+python3 -m venv
+source bin/activate.sh
 pip install conan
-# Install all needed dependencies inside a build folder
-CONAN_SYSREQUIRES_MODE=enabled conan install . --install-folder build --build missing
 # Build
-cmake -B build/ # or with ninja: cmake -B build/ -G Ninja
+cmake -B build/ -DCMAKE_BUILD_TYPE=Debug # or with ninja: cmake -B build/ -DCMAKE_BUILD_TYPE=Debug -G Ninja
 cmake --build build/
 cmake --install build/
 # Local test
 DESTDIR=appdir cmake --install build/
-./build/usr/local/bin/LinuxWindow
 # Local installer package
 cmake --build build/ --target package
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#/bin/sh
-clear
-echo "Building App..."
-clang++ -Wall -pedantic -o LinuxWindow -std=c++20 main.cpp src/FlatFoxRenderWarnings.cpp src/Renderer.cpp src/FlatFoxWindow.cpp src/FrameBufferObject.cpp src/SimplePhysics.cpp src/Camera.cpp src/SimpleObject.cpp src/VertexBuffer.cpp src/VertexArray.cpp src/IndexBuffer.cpp src/Shader.cpp src/Texture.cpp src/Imports/stb_image/stb_image.cpp  src/Seens/BasicMovement.cpp -L src/Imports/glfw/build/src/ -lglfw3 -L src/Imports/glew/lib/ -lGLEW

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-glew/2.2.0
-glfw/3.3.8
-glm/cci.20220420
-
-[generators]
-cmake


### PR DESCRIPTION
This removes the need to set a `conanfile.{py,txt}` and lets you keep using conventional CMake `find_package` and `target_link_library` calls.

I used Conan's `cmake_find_package` generator because `CMakeDeps`, the more modern thing, didn't generate a "Findglfw.cmake" in the `CMAKE_BINARY_DIR`, meaning I'd have to use `glfw` instead of `glfw::glfw` in the library linking step.